### PR TITLE
add zipped geotiff reading

### DIFF
--- a/src/veranda/raster/native/geotiff.py
+++ b/src/veranda/raster/native/geotiff.py
@@ -2,6 +2,7 @@
 
 import os
 import struct
+from zipfile import ZipFile
 import numpy as np
 from osgeo import gdal
 from typing import List
@@ -128,8 +129,15 @@ class GeoTiffFile:
             True if the given file is a BigTIFF, else False.
 
         """
-        with open(filepath, 'rb') as f:
-            header = f.read(4)
+        if '.zip' in filepath:
+            filepath = filepath.lstrip('/vsizip/')  # removes gdal virtual file system prefix to open w ZipFile
+            zip_filepath, inzip_filepath = filepath.split('.zip/')
+            with ZipFile(zip_filepath + '.zip') as zip:
+                with zip.open(inzip_filepath, 'r') as f:
+                    header = f.read(4)  # tests reads bytes not str, no need covert to bytearray
+        else:
+            with open(filepath, 'rb') as f:
+                header = f.read(4)
         byteorder = {b'II': '<', b'MM': '>', b'EP': '<'}[header[:2]]
         version = struct.unpack(byteorder + "H", header[2:4])[0]
         return version == 43
@@ -171,7 +179,19 @@ class GeoTiffFile:
 
         """
         if self.mode == 'r':
-            if not os.path.exists(self.filepath):
+            if '.zip' in self.filepath:
+                self.filepath = self.filepath.lstrip('/vsizip/')  # removes gdal virtual file system prefix if its there
+                zip_filepath, inzip_filepath = self.filepath.split('.zip/')
+                zip_filepath += '.zip'
+                if not os.path.exists(zip_filepath):  # checks zip file
+                    err_msg = f"File '{zip_filepath}' does not exist."
+                    raise FileNotFoundError(err_msg)
+                with ZipFile(zip_filepath) as zip:
+                    if inzip_filepath not in zip.namelist():  # checks file in zip
+                        err_msg = f"File '{self.filepath}' does not exist."
+                        raise FileNotFoundError(err_msg)
+                self.filepath = '/vsizip/' + self.filepath  # adds the gdal vsi prefix
+            elif not os.path.exists(self.filepath):
                 err_msg = f"File '{self.filepath}' does not exist."
                 raise FileNotFoundError(err_msg)
             self.src = gdal.Open(self.filepath, gdal.GA_ReadOnly)

--- a/src/veranda/raster/native/geotiff.py
+++ b/src/veranda/raster/native/geotiff.py
@@ -130,7 +130,7 @@ class GeoTiffFile:
 
         """
         if '.zip' in filepath:
-            filepath = filepath.lstrip('/vsizip/')  # removes gdal virtual file system prefix to open w ZipFile
+            filepath = filepath.replace('/vsizip/', '')  # removes gdal virtual file system prefix to open w ZipFile
             zip_filepath, inzip_filepath = filepath.split('.zip/')
             with ZipFile(zip_filepath + '.zip') as zip:
                 with zip.open(inzip_filepath, 'r') as f:
@@ -180,7 +180,7 @@ class GeoTiffFile:
         """
         if self.mode == 'r':
             if '.zip' in self.filepath:
-                self.filepath = self.filepath.lstrip('/vsizip/')  # removes gdal virtual file system prefix if its there
+                self.filepath = self.filepath.replace('/vsizip/', '')  # removes gdal virtual file system prefix if its there
                 zip_filepath, inzip_filepath = self.filepath.split('.zip/')
                 zip_filepath += '.zip'
                 if not os.path.exists(zip_filepath):  # checks zip file

--- a/src/veranda/raster/native/geotiff.py
+++ b/src/veranda/raster/native/geotiff.py
@@ -183,13 +183,13 @@ class GeoTiffFile:
             if '.zip' in self.filepath:
                 if self.filepath.startswith('/vsizip/'):
                     self.filepath = self.filepath[len('/vsizip/'):]  # removes gdal virtual file system prefix if its there
-                zip_filepath, inzip_filepath = self.filepath.split('.zip')
+                zip_filepath, inzip_filepath = self.filepath.split('.zip/')
                 zip_filepath += '.zip'
                 if not os.path.exists(zip_filepath):  # checks zip file
                     err_msg = f"File '{zip_filepath}' does not exist."
                     raise FileNotFoundError(err_msg)
                 with ZipFile(zip_filepath) as zip:
-                    if inzip_filepath[1:] not in zip.namelist():  # checks file in zip
+                    if inzip_filepath not in zip.namelist():  # checks file in zip
                         err_msg = f"File '{self.filepath}' does not exist."
                         raise FileNotFoundError(err_msg)
                 self.filepath = '/vsizip/' + self.filepath  # adds the gdal vsi prefix

--- a/src/veranda/raster/native/geotiff.py
+++ b/src/veranda/raster/native/geotiff.py
@@ -132,9 +132,9 @@ class GeoTiffFile:
         if '.zip' in filepath:
             if filepath.startswith('/vsizip/'):
                 filepath = filepath[len('/vsizip/'):]  # removes gdal virtual file system prefix to open w ZipFile
-            zip_filepath, inzip_filepath = filepath.split('.zip/')
+            zip_filepath, inzip_filepath = filepath.split('.zip')
             with ZipFile(zip_filepath + '.zip') as zip:
-                with zip.open(inzip_filepath, 'r') as f:
+                with zip.open(inzip_filepath[1:], 'r') as f:
                     header = f.read(4)  # tests reads bytes not str, no need covert to bytearray
         else:
             with open(filepath, 'rb') as f:
@@ -183,13 +183,13 @@ class GeoTiffFile:
             if '.zip' in self.filepath:
                 if self.filepath.startswith('/vsizip/'):
                     self.filepath = self.filepath[len('/vsizip/'):]  # removes gdal virtual file system prefix if its there
-                zip_filepath, inzip_filepath = self.filepath.split('.zip/')
+                zip_filepath, inzip_filepath = self.filepath.split('.zip')
                 zip_filepath += '.zip'
                 if not os.path.exists(zip_filepath):  # checks zip file
                     err_msg = f"File '{zip_filepath}' does not exist."
                     raise FileNotFoundError(err_msg)
                 with ZipFile(zip_filepath) as zip:
-                    if inzip_filepath not in zip.namelist():  # checks file in zip
+                    if inzip_filepath[1:] not in zip.namelist():  # checks file in zip
                         err_msg = f"File '{self.filepath}' does not exist."
                         raise FileNotFoundError(err_msg)
                 self.filepath = '/vsizip/' + self.filepath  # adds the gdal vsi prefix

--- a/src/veranda/raster/native/geotiff.py
+++ b/src/veranda/raster/native/geotiff.py
@@ -183,13 +183,13 @@ class GeoTiffFile:
             if '.zip' in self.filepath:
                 if self.filepath.startswith('/vsizip/'):
                     self.filepath = self.filepath[len('/vsizip/'):]  # removes gdal virtual file system prefix if its there
-                zip_filepath, inzip_filepath = self.filepath.split('.zip/')
+                zip_filepath, inzip_filepath = self.filepath.split('.zip')
                 zip_filepath += '.zip'
                 if not os.path.exists(zip_filepath):  # checks zip file
                     err_msg = f"File '{zip_filepath}' does not exist."
                     raise FileNotFoundError(err_msg)
                 with ZipFile(zip_filepath) as zip:
-                    if inzip_filepath not in zip.namelist():  # checks file in zip
+                    if inzip_filepath[1:] not in zip.namelist():  # checks file in zip
                         err_msg = f"File '{self.filepath}' does not exist."
                         raise FileNotFoundError(err_msg)
                 self.filepath = '/vsizip/' + self.filepath  # adds the gdal vsi prefix

--- a/src/veranda/raster/native/geotiff.py
+++ b/src/veranda/raster/native/geotiff.py
@@ -130,7 +130,8 @@ class GeoTiffFile:
 
         """
         if '.zip' in filepath:
-            filepath = filepath.replace('/vsizip/', '')  # removes gdal virtual file system prefix to open w ZipFile
+            if filepath.startswith('/vsizip/'):
+                filepath = filepath[len('/vsizip/'):]  # removes gdal virtual file system prefix to open w ZipFile
             zip_filepath, inzip_filepath = filepath.split('.zip/')
             with ZipFile(zip_filepath + '.zip') as zip:
                 with zip.open(inzip_filepath, 'r') as f:
@@ -180,7 +181,8 @@ class GeoTiffFile:
         """
         if self.mode == 'r':
             if '.zip' in self.filepath:
-                self.filepath = self.filepath.replace('/vsizip/', '')  # removes gdal virtual file system prefix if its there
+                if self.filepath.startswith('/vsizip/'):
+                    self.filepath = self.filepath[len('/vsizip/'):]  # removes gdal virtual file system prefix if its there
                 zip_filepath, inzip_filepath = self.filepath.split('.zip/')
                 zip_filepath += '.zip'
                 if not os.path.exists(zip_filepath):  # checks zip file

--- a/tests/raster/native/geotiff/test_geotiff.py
+++ b/tests/raster/native/geotiff/test_geotiff.py
@@ -151,7 +151,7 @@ def test_read_one_band_zip(filepath):
             src.write(data)
         zip.write(filepath)
 
-    read_filepath = zip_filepath + '/' + filename
+    read_filepath = os.path.join(zip_filepath, filename)
 
     with GeoTiffFile(read_filepath) as src:
         ds = src.read()

--- a/tests/raster/native/geotiff/test_geotiff.py
+++ b/tests/raster/native/geotiff/test_geotiff.py
@@ -3,6 +3,7 @@ import pytest
 import numpy as np
 from osgeo import gdal
 from tempfile import mkdtemp
+from zipfile import ZipFile
 
 from veranda.raster.native.geotiff import GeoTiffFile
 
@@ -137,3 +138,24 @@ def test_sref(filepath):
             sref_val = src.sref_wkt
 
         assert sref_val == sref_ref
+
+
+def test_read_one_band_zip(filepath):
+    data = np.ones((1, 100, 100), dtype=np.float32)
+
+    filename = os.path.basename(filepath)
+    zip_filepath = os.path.splitext(filepath)[0] + r'.zip'
+
+    with ZipFile(zip_filepath, 'w') as zip:
+        with GeoTiffFile(filepath, mode='w') as src:
+            src.write(data)
+        zip.write(filepath)
+
+    read_filepath = zip_filepath + '/' + filename
+
+    with GeoTiffFile(read_filepath) as src:
+        ds = src.read()
+
+    np.testing.assert_array_equal(ds[1], data[0, :, :])
+
+    os.remove(zip_filepath)

--- a/tests/raster/native/geotiff/test_geotiff.py
+++ b/tests/raster/native/geotiff/test_geotiff.py
@@ -151,7 +151,7 @@ def test_read_one_band_zip(filepath):
             src.write(data)
         zip.write(filepath)
 
-    read_filepath = os.path.join(zip_filepath, filename)
+    read_filepath = zip_filepath + '/' + filename
 
     with GeoTiffFile(read_filepath) as src:
         ds = src.read()

--- a/tests/raster/native/geotiff/test_geotiff.py
+++ b/tests/raster/native/geotiff/test_geotiff.py
@@ -141,6 +141,7 @@ def test_sref(filepath):
 
 
 def test_read_one_band_zip(filepath):
+
     data = np.ones((1, 100, 100), dtype=np.float32)
 
     filename = os.path.basename(filepath)
@@ -151,7 +152,9 @@ def test_read_one_band_zip(filepath):
             src.write(data)
         zip.write(filepath)
 
-    read_filepath = zip_filepath + '/' + filename
+        in_zip_filename = [name for name in zip.namelist() if name.endswith('.tif')][0]
+
+    read_filepath = os.path.join(zip_filepath, in_zip_filename)
 
     with GeoTiffFile(read_filepath) as src:
         ds = src.read()


### PR DESCRIPTION
allows reading of geotiff files in zip folders. 

- uses zipfile module to check paths and file existence. 
- geotiff zip read access by gdal se [here](https://gdal.org/user/virtual_file_systems.html). 
- should work with filepaths with '/vsizip/{path to zipfile}/{in zip path to geotiff}' or without '/vsizip/'.
- sample use case and tested with [hpar-reader](https://github.com/TUW-GEO/hpar-reader) 
- other compressed folders (ex. tar, gzip, etc.) could be added in the future but need zipfile like library check or use gdal functions which look clunky at the moment. 